### PR TITLE
Update Home.css

### DIFF
--- a/src/components/Home.css
+++ b/src/components/Home.css
@@ -629,7 +629,7 @@ br
   margin-bottom: 10px;
   box-shadow: 0 0 20px rgba(0, 212, 255, 0.8); /* Neon glow */
   transition: transform 0.6s ease, box-shadow 0.4s ease;
-  z-index: 2;
+  z-index: 0;
 }
 
 .coordinator img:hover {
@@ -731,6 +731,8 @@ footer {
   box-shadow: 0 0 50px rgba(0, 255, 255, 0.6); /* Futuristic glow */
   border-top: 2px solid rgba(0, 255, 255, 0.3);
   text-align: center;
+  z-index: -1;
+  
 }
 
 .footer-content {


### PR DESCRIPTION
"Bug Fixes"

Resolve navbar overlap issue for coordinator section & footer

Coordinator image section and footer elements were overlapping on top of the navigation bar. Updated the CSS z-index values to fix layering issues:

1. Changed coordinator image section z-index from 2 → 0

2. Added z-index: -1 for the footer section

This ensures proper stacking order and prevents UI overlap.